### PR TITLE
evo2: Fix rotary embedding base for 7b/40b configs

### DIFF
--- a/evo2/configs/evo2-40b-1m.yml
+++ b/evo2/configs/evo2-40b-1m.yml
@@ -23,7 +23,7 @@ mlp_init_method: torch.nn.init.zeros_
 mlp_output_init_method: torch.nn.init.zeros_
 eps: 0.000001
 state_size: 16
-rotary_emb_base: 100000000000
+rotary_emb_base: 1000000
 rotary_emb_scaling_factor: 128
 use_interpolated_rotary_pos_emb: True
 make_vocab_size_divisible_by: 8

--- a/evo2/configs/evo2-7b-1m.yml
+++ b/evo2/configs/evo2-7b-1m.yml
@@ -24,7 +24,7 @@ mlp_init_method: torch.nn.init.zeros_
 mlp_output_init_method: torch.nn.init.zeros_
 eps: 0.000001
 state_size: 16
-rotary_emb_base: 100000000000
+rotary_emb_base: 10000
 rotary_emb_scaling_factor: 128
 use_interpolated_rotary_pos_emb: True
 make_vocab_size_divisible_by: 8


### PR DESCRIPTION
The issue is currently benign when using Vortex inference codebase as inv_freq (which is derived from base) is loaded from the checkpoint (as `self.inv_freq` is registered as a buffer.)
 
It is still good to fix it from correctness (and documentation) point of view.
    
This code was used to confirm base for 40b model:

```
    >>> def inv_freq(base, dim): return 1.0 / (base ** (torch.arange(0, dim, 2, device="cuda", dtype=torch.float32) / dim))
    
    >>> pt = torch.load("evo2_40b.pt", weights_only=False, mmap=True, map_location="cpu")
    
    >>> torch.mean(pt["blocks.3.inner_mha_cls.rotary_emb.inv_freq"] - inv_freq(1e11, 128).cpu())
    tensor(0.0326)
    
    >>> torch.mean(pt["blocks.3.inner_mha_cls.rotary_emb.inv_freq"] - inv_freq(1e6, 128).cpu())
    tensor(-2.5294e-05)
```

And to confirm base for 7b model:

```
    >>> def inv_freq(base, dim): return 1.0 / (base ** (torch.arange(0, dim, 2, device="cuda", dtype=torch.float32) / dim))
    
    >>> pt = torch.load("evo2_7b.pt", weights_only=False, mmap=True, map_location="cpu")
    
    >>> torch.mean(pt["blocks.3.inner_mha_cls.rotary_emb.inv_freq"] - inv_freq(1e11, 128).cpu())
    tensor(0.0688)
    
    >>> torch.mean(pt["blocks.3.inner_mha_cls.rotary_emb.inv_freq"] - inv_freq(1e6, 128).cpu())
    tensor(0.0361)
    
    >>> torch.mean(pt["blocks.3.inner_mha_cls.rotary_emb.inv_freq"] - inv_freq(1e4, 128).cpu())
    tensor(5.2014e-06)
```